### PR TITLE
require privs privilege

### DIFF
--- a/gui.lua
+++ b/gui.lua
@@ -4,6 +4,9 @@ gui = {}
 minetest.register_chatcommand("privareas", {
 	params = "",
 	description = "PrivAreas: access a formspec from the privilegeareas mod",
+	privs = {
+		privs = true,
+	},
 	func = function(name, param)
 		add_gui(name)
 	end,


### PR DESCRIPTION
Even though it may make sense to have a more specific privilege to protect the /privareas command, I think that "privs" should be required at the very least, since by being able to grant and revoke arbitrary privileges through a privilege area, a player can do approximately the same as if the "privs" privilege was available.